### PR TITLE
BUG: 37 Fetch all members on client initialization

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ const cron = require('node-cron')
 let Discord = require('discord.js')
 const { connect, makeUser, makeGuild } = require('./library/persistence')
 
-let client = new Discord.Client()
+let client = new Discord.Client({ fetchAllMembers: true })
 
 // client appends
 client.settings = require('./settings/settings.json')


### PR DESCRIPTION
See issue #37, the symptom of which was that `p!stats`, time-tracking, and #practice-room-chat permissions would not work for certain users appearing offline. The reason is because those users are not in the cache; for sufficiently large guilds, Discord does not return info on offline guild members on initial startup. As a result, the `voiceStateUpdate` event handler was called with incomplete `member` objects, and `p!stats` failed to find users in the `members` cache.

One possible fix was to use `fetchMember()` instead of the `members` cache, but as this would not solve the time-tracking and #practice-room-chat issues, here is a much simpler fix: client initialization has a `fetchAllMembers` flag, which is disabled by default. This enables the flag.