### PR TITLE
FEATURE: automatic VC creation

### DIFF
--- a/library/client_events.js
+++ b/library/client_events.js
@@ -101,7 +101,9 @@ module.exports = client => {
       function areAllPracticeRoomsFull (restwo) {
         let isFull = true
         restwo.permitted_channels.forEach(chanId => {
-          if (client.guilds.get(newMember.guild.id).channels.get(chanId).members.size === 0) {
+          let chan = client.guilds.get(newMember.guild.id).channels.get(chanId)
+          // channel being null might happen if we have a stale channel in the db - just ignore if this happens.
+          if (chan != null && chan.members.size === 0) {
             isFull = false
           }
         })
@@ -116,7 +118,7 @@ module.exports = client => {
         let tempChannelToRemove = null
         restwo.permitted_channels.forEach(chanId => {
           let chan = client.guilds.get(newMember.guild.id).channels.get(chanId)
-          if (chan.members.size === 0) {
+          if (chan != null && chan.members.size === 0) {
             emptyCount++
             if (chan.name === 'Extra Practice Room') {
               tempChannelToRemove = chan


### PR DESCRIPTION
Creates a new voice channel called "Extra Practice Room" if all registered PRs are occupied by either muted or unmuted users. Muted or unmuted doesn't matter because we want to discourage people from using rooms that are occupied even if all the participants are currently muted - it could be the case that someone was practising there but was just muted temporarily.

If the practice rooms *aren't* full, the bot checks to see if it should remove one of the temp rooms. It will remove a temp room if there are at least two empty rooms, and one of those empty rooms is a temp room. (If none of the empty rooms is a temp room, then the only rooms we can remove are the main rooms, which we don't want to remove. If there is only one empty room, we need that room to be available.)