### PR TITLE
BUG: 36 ignore ghost sessions in VC auto-creation and live leaderboard code

### DIFF
--- a/library/client_events.js
+++ b/library/client_events.js
@@ -110,7 +110,7 @@ module.exports = client => {
       guildInfo.permitted_channels.forEach(chanId => {
         let chan = client.guilds.get(newMember.guild.id).channels.get(chanId)
         // channel being null might happen if we have a stale channel in the db - just ignore if this happens.
-        if (chan != null && chan.members.size === 0) {
+        if (chan != null && !chan.members.exists(m => !m.deleted)) {
           isFull = false
         }
       })
@@ -125,7 +125,7 @@ module.exports = client => {
       let tempChannelToRemove = null
       guildInfo.permitted_channels.forEach(chanId => {
         let chan = client.guilds.get(newMember.guild.id).channels.get(chanId)
-        if (chan != null && chan.members.size === 0) {
+        if (chan != null && !chan.members.exists(m => !m.deleted)) {
           emptyCount++
           if (chan.name === 'Extra Practice Room') {
             tempChannelToRemove = chan

--- a/library/leaderboard_fetch.js
+++ b/library/leaderboard_fetch.js
@@ -19,7 +19,7 @@ module.exports = (client, db) => {
       if (vc != null) {
         vc.members.forEach(member => {
           // these conditions should be equivalent but maybe they were already pracking when the bot came up.
-          if (!member.mute && member.s_time != null) {
+          if (!member.mute && member.s_time != null && !member.deleted) {
             currentPrackers.set(member.user.id, moment().unix() - member.s_time)
           }
         })


### PR DESCRIPTION
Due to a Discord bug, users who leave the server while in a VC never emit the
voiceStateUpdate event to tell us they're leaving. As a result, the user stays
in the channel, accumulates time if unmuted, and counts as occupying the room
for the purposes of VC autocreation. This change ignores GuildMember objects
that have the `deleted` flag set to `true`.