### PR TITLE
Implement p!lock and p!unlock

### DIFF
--- a/commands/general/lock.js
+++ b/commands/general/lock.js
@@ -1,0 +1,37 @@
+module.exports.load = (client) => {
+  client.commands['lock'] = {
+    async run (message) {
+      var channel = message.member.voiceChannel
+      if (channel == null) {
+        return client.errorMessage(message, 'You are not currently in a channel.')
+      }
+
+      let guildInfo = await client.loadGuildData(message.guild.id)
+      if (!guildInfo.permitted_channels.includes(message.member.voiceChannelID)) {
+        return client.errorMessage(message, 'This channel is not a registered practice room.')
+      }
+
+      if (channel.locked_by != null) {
+        return client.errorMessage(message, 'This channel is already locked.')
+      }
+
+      channel.locked_by = message.author.id
+      channel.overwritePermissions(message.author, { SPEAK: true })
+      let everyone = message.guild.roles.find('name', '@everyone')
+      channel.overwritePermissions(everyone, { SPEAK: false }) // deny everyone speaking permissions
+      try {
+        await Promise.all(channel.members.map(async (m) => {
+          if (m !== message.member) {
+            return m.setMute(true)
+          }
+        }))
+      } catch (err) {
+        // this is likely an issue with trying to mute a user who has already left the channel
+        console.log(err)
+      }
+
+      let m = await message.reply(`locked channel <#${channel.id}>.`)
+      setTimeout(() => m.delete(), client.settings.res_destruct_time * 1000)
+    }
+  }
+}

--- a/commands/general/lock.js
+++ b/commands/general/lock.js
@@ -21,7 +21,7 @@ module.exports.load = (client) => {
       channel.overwritePermissions(everyone, { SPEAK: false }) // deny everyone speaking permissions
       try {
         await Promise.all(channel.members.map(async (m) => {
-          if (m !== message.member) {
+          if (m !== message.member && !m.deleted) {
             return m.setMute(true)
           }
         }))

--- a/commands/general/unlock.js
+++ b/commands/general/unlock.js
@@ -1,0 +1,29 @@
+module.exports.load = (client) => {
+  client.commands['unlock'] = {
+    async run (message) {
+      let args = message.content.split(' ').splice(1)
+      let channel
+      if (args.length >= 1) {
+        if (!message.member.roles.find('name', 'Bot Manager')) {
+          return client.errorMessage(message, 'You must be a Bot Manager to unlock other rooms.')
+        }
+
+        channel = client.channels.get(args[0].replace(/[<#>]/g, ''))
+      } else {
+        channel = message.member.voiceChannel
+        if (channel == null) {
+          return client.errorMessage(message, 'You are not currently in a channel.')
+        }
+      }
+
+      if (channel.locked_by !== message.author.id && !message.member.roles.find('name', 'Bot Manager')) {
+        return client.errorMessage(message, 'You do not have this channel locked.')
+      }
+
+      await client.unlockPracticeRoom(message.guild, message.author, channel)
+
+      let m = await message.reply(`unlocked channel <#${channel.id}>.`)
+      setTimeout(() => m.delete(), client.settings.res_destruct_time * 1000)
+    }
+  }
+}

--- a/commands/general/unlock.js
+++ b/commands/general/unlock.js
@@ -20,7 +20,7 @@ module.exports.load = (client) => {
         return client.errorMessage(message, 'You do not have this channel locked.')
       }
 
-      await client.unlockPracticeRoom(message.guild, message.author, channel)
+      await client.unlockPracticeRoom(message.guild, channel.locked_by, channel)
 
       let m = await message.reply(`unlocked channel <#${channel.id}>.`)
       setTimeout(() => m.delete(), client.settings.res_destruct_time * 1000)

--- a/library/client_events.js
+++ b/library/client_events.js
@@ -176,7 +176,7 @@ module.exports = client => {
       await client.writeUserData(newMember.user.id, userInfo)
       client.log(`User created for ${newMember.user.username}#${newMember.user.discriminator}`)
     } else {
-      if (newMember.serverMute && newMember.voiceChannel.locked_by == null && !newMember.roles.exists(r => r.name === 'Temp Muted')) {
+      if (newMember.serverMute && newMember.voiceChannel != null && newMember.voiceChannel.locked_by == null && !newMember.roles.exists(r => r.name === 'Temp Muted')) {
         // they're server muted, but they're in an unlocked channel - means they probably left a locked room.
         try {
           newMember.setMute(false)

--- a/library/client_events.js
+++ b/library/client_events.js
@@ -188,7 +188,7 @@ module.exports = client => {
 
       if (oldMember.voiceChannel != null && oldMember.voiceChannel.locked_by === oldMember.id && newMember.voiceChannelID !== oldMember.voiceChannelID) {
         // user left a room they had locked; unlock it
-        await client.unlockPracticeRoom(oldMember.guild, oldMember.user, oldMember.voiceChannel)
+        await client.unlockPracticeRoom(oldMember.guild, oldMember.id, oldMember.voiceChannel)
       }
 
       mutex.runExclusive(async () => {

--- a/library/client_functions.js
+++ b/library/client_functions.js
@@ -1,6 +1,7 @@
 const moment = require('moment')
 const promisify = require('util').promisify
 const readdir = promisify(require('fs').readdir)
+const Discord = require('discord.js')
 
 module.exports = client => {
   client.log = (string) => {
@@ -69,5 +70,34 @@ module.exports = client => {
     })
 
     setTimeout(() => m.delete(), client.settings.res_destruct_time * 1000)
+  }
+
+  client.unlockPracticeRoom = async (guild, user, channel) => {
+    channel.locked_by = null
+
+    // remove permissions overrides
+    let everyone = guild.roles.find('name', '@everyone')
+    channel.overwritePermissions(everyone, { SPEAK: null })
+
+    let personalOverride = channel.permissionOverwrites.get(user.id)
+    // existingOverride shouldn't be null unless someone manually deletes the override, but if for some reason it's gone, no big deal, just move on.
+    if (personalOverride != null) {
+      if (personalOverride.allowed.bitfield === Discord.Permissions.FLAGS.SPEAK && personalOverride.denied.bitfield === 0) { // the only permission was allow SPEAK
+        personalOverride.delete()
+      } else {
+        channel.overwritePermissions(user, { SPEAK: null })
+      }
+    }
+
+    try {
+      await Promise.all(channel.members.map(async m => {
+        if (!m.roles.exists(r => r.name === 'Temp Muted')) {
+          return m.setMute(false)
+        }
+      }))
+    } catch (err) {
+      // this is likely an issue with trying to mute a user who has already left the channel
+      console.log(err)
+    }
   }
 }

--- a/library/client_functions.js
+++ b/library/client_functions.js
@@ -72,20 +72,20 @@ module.exports = client => {
     setTimeout(() => m.delete(), client.settings.res_destruct_time * 1000)
   }
 
-  client.unlockPracticeRoom = async (guild, user, channel) => {
+  client.unlockPracticeRoom = async (guild, userId, channel) => {
     channel.locked_by = null
 
     // remove permissions overrides
     let everyone = guild.roles.find('name', '@everyone')
     channel.overwritePermissions(everyone, { SPEAK: null })
 
-    let personalOverride = channel.permissionOverwrites.get(user.id)
+    let personalOverride = channel.permissionOverwrites.get(userId)
     // existingOverride shouldn't be null unless someone manually deletes the override, but if for some reason it's gone, no big deal, just move on.
     if (personalOverride != null) {
       if (personalOverride.allowed.bitfield === Discord.Permissions.FLAGS.SPEAK && personalOverride.denied.bitfield === 0) { // the only permission was allow SPEAK
         personalOverride.delete()
       } else {
-        channel.overwritePermissions(user, { SPEAK: null })
+        channel.overwritePermissions(userId, { SPEAK: null })
       }
     }
 

--- a/library/client_functions.js
+++ b/library/client_functions.js
@@ -91,7 +91,7 @@ module.exports = client => {
 
     try {
       await Promise.all(channel.members.map(async m => {
-        if (!m.roles.exists(r => r.name === 'Temp Muted')) {
+        if (!m.deleted && !m.roles.exists(r => r.name === 'Temp Muted')) {
           return m.setMute(false)
         }
       }))


### PR DESCRIPTION
Implements user commands to take and release exclusive control of practice rooms. A few API complications informed the design:

- `p!lock` checks if the user is currently in a channel and locks the channel if not already locked (assuming the channel is a registered practice room). Locking a room involves changing permissions on the room such that @everyone is denied the SPEAK permission, and an override is added for the occupant to allow the SPEAK permission. Additionally, everybody else in the room becomes server muted (this is because denying the SPEAK permission does not mute users who are currently in the room. The reason why we don't solely rely on server mutes is because there may be a delay between when an unmuted user enters a locked room and when a server mute kicks in.)

- `p!unlock` checks if the user is in a channel locked by them, then unlocks the room by undoing the permissions changes and server unmuting all users (if they were already server unmuted, this still has the effect of unmuting users who are muted by virtue of having been denied the SPEAK permission). Bot Managers can unlock rooms they don't have locked themselves (or rooms they're not in).

- the time calculation is modified so that we don't start the timer if the room is locked by someone else - this is because being muted by virtue of permission does not actually reflect in the `mute` and `selfMute` properties of `GuildMember`. Without this change, a user who joins a locked room and is yet server unmuted would be live.

- the occupant leaving a locked room automatically unlocks the room.

- anybody else leaving a locked room should be unmuted. However... if they aren't in a channel anymore, we can't actually modify their muted/unmuted status. Hence, we unmute them if they ever join an unlocked channel. One concern, of course, is that they may be server muted for other reasons - i.e. manually, by a moderator. As a result, the bot will never unmute users with the Temp Muted role.