### PR TITLE
Fix position tracking for live users, abbreviate p!lb overall to p!lb o

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -93,7 +93,7 @@ class Commands {
       'Displays this help message')
     msg.addField(`\`${settings.prefix}stats [ USERNAME#DISCRIMINATOR ]\``,
       'Displays practice statistics for the specified user (default: calling user)')
-    msg.addField(`\`${settings.prefix}lb, ${settings.prefix}leaderboard [ weekly | overall ]\``,
+    msg.addField(`\`${settings.prefix}lb, ${settings.prefix}leaderboard [ [w]eekly | [o]verall ]\``,
       'Displays the weekly or overall leaderboard (default: weekly)')
 
     if (isBotManager) {
@@ -139,15 +139,15 @@ class Commands {
 
   async leaderboard (message) {
     let args = message.content.split(' ').splice(1)
-    if (args.length === 0 || args[0] === 'weekly') {
+    if (args.length === 0 || args[0] === 'weekly' || args[0] === 'w') {
       let data = await this.client.getWeeklyLeaderboard(message.guild, message.author)
       this._sendLeaderboard(message.channel, data, 'Weekly', 'overall')
-    } else if (args[0] === 'overall') {
+    } else if (args[0] === 'overall' || args[0] === 'o') {
       let data = await this.client.getOverallLeaderboard(message.guild, message.author)
       this._sendLeaderboard(message.channel, data, 'Overall', 'weekly')
     } else {
       let command = message.content.split(' ')[0]
-      throw new Error(`Usage: \`${command} [ weekly | overall ]\``)
+      throw new Error(`Usage: \`${command} [ [w]eekly | [o]verall ]\``)
     }
   }
 

--- a/library/leaderboard.js
+++ b/library/leaderboard.js
@@ -131,16 +131,18 @@ module.exports = (client) => {
       if (currentId !== userId) {
         let otherUser = await client.userRepository.load(currentId)
         let otherTime = 0
+        let dbTime = 0
         if (otherUser == null || playtimeFn(otherUser) === 0) {
           // an active user who won't show up in getSessionCount() => increment the total number of users
           totalCount++
         } else {
-          otherTime += playtimeFn(otherUser)
+          dbTime = playtimeFn(otherUser)
+          otherTime += dbTime
         }
 
         otherTime += currentTime
-        if (otherTime > totalTime) {
-          // this active user has passed us
+        if (otherTime > totalTime && totalTime > dbTime) {
+          // this active user started out behind us but has passed us
           tentativeRank++
         }
       }


### PR DESCRIPTION
p!lb abbreviation per customer request.

Position tracking bug is a fairly simple one - for live users we calculate our current time, get what rank that current time would hold in the DB, then increment the rank for every live user ahead of us. We needed to increment the rank for every live user ahead of us *who started out behind us* per the DB - i.e. they actually leapfrogged us, they weren't there to begin with.