### PR TITLE
Allow temp rooms to be deleted even if name has changed

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -225,7 +225,7 @@ class Commands {
           throw new Error(`Usage: \`${usageStr}\``)
       }
     } else {
-      let msg = `Currently registered practice rooms:\n\`\`\`\n`
+      let msg = 'Currently registered practice rooms:\n\`\`\`\n'
       guildInfo.permitted_channels
         .map(chanId => message.guild.channels.get(chanId))
         .filter(chan => chan != null)
@@ -236,6 +236,10 @@ class Commands {
             msg += ` (channel ID: ${chan.id})`
           }
 
+          if (chan.isTempRoom) {
+            msg += ' (TEMP)'
+          }
+
           if (chan.locked_by != null) {
             let occupant = chan.members.get(`${chan.locked_by}`)
             msg += ` LOCKED by ${occupant.user.username}#${occupant.user.discriminator}`
@@ -244,18 +248,18 @@ class Commands {
           chan.members.forEach(m => {
             msg += `\n  - ${m.user.username}#${m.user.discriminator}`
             if (m.deleted) {
-              msg += ` (GHOST)`
+              msg += ' (GHOST)'
             }
 
             if (m.s_time != null) {
-              msg += ` (LIVE)`
+              msg += ' (LIVE)'
             }
           })
 
           msg += '\n'
         })
 
-      msg += `\`\`\``
+      msg += '\`\`\`'
       message.channel.send(msg)
     }
   }

--- a/commands.js
+++ b/commands.js
@@ -225,7 +225,7 @@ class Commands {
           throw new Error(`Usage: \`${usageStr}\``)
       }
     } else {
-      let msg = 'Currently registered practice rooms:\n\`\`\`\n'
+      let msg = 'Currently registered practice rooms:\n```\n'
       guildInfo.permitted_channels
         .map(chanId => message.guild.channels.get(chanId))
         .filter(chan => chan != null)
@@ -259,7 +259,7 @@ class Commands {
           msg += '\n'
         })
 
-      msg += '\`\`\`'
+      msg += '```'
       message.channel.send(msg)
     }
   }

--- a/library/client_events.js
+++ b/library/client_events.js
@@ -29,10 +29,10 @@ async function findChannelToRemove (permittedChannels, guild) {
   if (emptyRooms.length >= 2) {
     if (emptyRooms.filter(chan => chan.bitrate !== 64).length <= 1) {
       // there's at most one high-bitrate room - remove the first temp channel that's low-bitrate, if it exists
-      tempChannelToRemove = emptyRooms.find(c => c.bitrate === 64 && c.name === 'Extra Practice Room')
+      tempChannelToRemove = emptyRooms.find(c => c.bitrate === 64 && (c.name === 'Extra Practice Room' || c.isTempRoom))
     } else {
       // just remove the first temp channel, regardless of bitrate
-      tempChannelToRemove = emptyRooms.find(c => c.name === 'Extra Practice Room')
+      tempChannelToRemove = emptyRooms.find(c => c.name === 'Extra Practice Room' || c.isTempRoom)
     }
   }
 
@@ -161,6 +161,8 @@ module.exports = client => {
           deny: ['VIEW_CHANNEL']
         }]
       })
+
+      newChan.isTempRoom = true
 
       // update the db
       await client.guildRepository.addToField(guildInfo, 'permitted_channels', newChan.id)

--- a/library/client_events.js
+++ b/library/client_events.js
@@ -167,7 +167,7 @@ module.exports = client => {
       // update the db
       await client.guildRepository.addToField(guildInfo, 'permitted_channels', newChan.id)
     } else {
-      let tempChannelToRemove = findChannelToRemove(guildInfo.permitted_channels, newMember.guild)
+      let tempChannelToRemove = await findChannelToRemove(guildInfo.permitted_channels, newMember.guild)
       if (tempChannelToRemove != null) {
         // before removing the channel from the guild, remove it in the db.
         await client.guildRepository.removeFromField(guildInfo, 'permitted_channels', tempChannelToRemove.id)


### PR DESCRIPTION
Certain staff members have a habit of renaming extra practice rooms and then deleting them without unregistering *ahem*... this lets the bot take care of the extra practice rooms even if they're renamed.