### PR TITLE
Fixes for #67, #44, #23

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -225,7 +225,7 @@ class Commands {
           throw new Error(`Usage: \`${usageStr}\``)
       }
     } else {
-      let msg = `Currently registered practice rooms:\n\`\`\`\n`
+      let msg = 'Currently registered practice rooms:\n\`\`\`\n'
       guildInfo.permitted_channels
         .map(chanId => message.guild.channels.get(chanId))
         .filter(chan => chan != null)
@@ -236,6 +236,10 @@ class Commands {
             msg += ` (channel ID: ${chan.id})`
           }
 
+          if (chan.isTempRoom) {
+            msg += ' (TEMP)'
+          }
+
           if (chan.locked_by != null) {
             let occupant = chan.members.get(`${chan.locked_by}`)
             msg += ` LOCKED by ${occupant.user.username}#${occupant.user.discriminator}`
@@ -244,18 +248,18 @@ class Commands {
           chan.members.forEach(m => {
             msg += `\n  - ${m.user.username}#${m.user.discriminator}`
             if (m.deleted) {
-              msg += ` (GHOST)`
+              msg += ' (GHOST)'
             }
 
             if (m.s_time != null) {
-              msg += ` (LIVE)`
+              msg += ' (LIVE)'
             }
           })
 
           msg += '\n'
         })
 
-      msg += `\`\`\``
+      msg += '\`\`\`'
       message.channel.send(msg)
     }
   }

--- a/commands.js
+++ b/commands.js
@@ -63,6 +63,12 @@ class Commands {
     selfDestructMessage(() => message.reply('added time to user.'))
   }
 
+  async commit (message) {
+    requireRole(message.member)
+    await this.client.saveAllUsersTime(message.guild)
+    selfDestructMessage(() => message.reply('committed all active sessions to storage.'))
+  }
+
   async deltime (message) {
     requireRole(message.member)
 
@@ -116,6 +122,8 @@ class Commands {
         'Adds practice time to a user\'s record')
       msg.addField(`\`${settings.prefix}deltime @user TIME_IN_SECONDS\``,
         'Removes practice time from a user\'s record')
+      msg.addField(`\`${settings.prefix}commit\``,
+        'Commits all active practice sessions to storage')
     }
 
     msg.setColor(settings.embed_color)
@@ -421,6 +429,7 @@ function loadCommands (client) {
   client.commands = {}
 
   client.commands['addtime'] = (message) => { return c.addtime(message) }
+  client.commands['commit'] = (message) => { return c.commit(message) }
   client.commands['deltime'] = (message) => { return c.deltime(message) }
   client.commands['help'] = (message) => { return c.help(message) }
   client.commands['leaderboard'] = client.commands['lb'] = (message) => { return c.leaderboard(message) }

--- a/commands.js
+++ b/commands.js
@@ -225,7 +225,7 @@ class Commands {
           throw new Error(`Usage: \`${usageStr}\``)
       }
     } else {
-      let msg = 'Currently registered practice rooms:\n\`\`\`\n'
+      let msg = 'Currently registered practice rooms:\n```\n'
       guildInfo.permitted_channels
         .map(chanId => message.guild.channels.get(chanId))
         .filter(chan => chan != null)
@@ -259,7 +259,7 @@ class Commands {
           msg += '\n'
         })
 
-      msg += '\`\`\`'
+      msg += '```'
       message.channel.send(msg)
     }
   }

--- a/library/client_events.js
+++ b/library/client_events.js
@@ -29,10 +29,10 @@ async function findChannelToRemove (permittedChannels, guild) {
   if (emptyRooms.length >= 2) {
     if (emptyRooms.filter(chan => chan.bitrate !== 64).length <= 1) {
       // there's at most one high-bitrate room - remove the first temp channel that's low-bitrate, if it exists
-      tempChannelToRemove = emptyRooms.find(c => c.bitrate === 64 && c.name === 'Extra Practice Room')
+      tempChannelToRemove = emptyRooms.find(c => c.bitrate === 64 && (c.name === 'Extra Practice Room' || c.isTempRoom))
     } else {
       // just remove the first temp channel, regardless of bitrate
-      tempChannelToRemove = emptyRooms.find(c => c.name === 'Extra Practice Room')
+      tempChannelToRemove = emptyRooms.find(c => c.name === 'Extra Practice Room' || c.isTempRoom)
     }
   }
 
@@ -161,6 +161,8 @@ module.exports = client => {
           deny: ['VIEW_CHANNEL']
         }]
       })
+
+      newChan.isTempRoom = true
 
       // update the db
       await client.guildRepository.addToField(guildInfo, 'permitted_channels', newChan.id)

--- a/library/client_events.js
+++ b/library/client_events.js
@@ -167,7 +167,7 @@ module.exports = client => {
       // update the db
       await client.guildRepository.addToField(guildInfo, 'permitted_channels', newChan.id)
     } else {
-      let tempChannelToRemove = findChannelToRemove(guildInfo.permitted_channels, newMember.guild)
+      let tempChannelToRemove = await findChannelToRemove(guildInfo.permitted_channels, newMember.guild)
       if (tempChannelToRemove != null) {
         // before removing the channel from the guild, remove it in the db.
         await client.guildRepository.removeFromField(guildInfo, 'permitted_channels', tempChannelToRemove.id)

--- a/library/leaderboard.js
+++ b/library/leaderboard.js
@@ -154,6 +154,7 @@ module.exports = (client) => {
   client.submitWeek = async () => {
     let pinano = client.guilds.get('188345759408717825')
     let data = await client.getWeeklyLeaderboard(pinano, null)
+    await client.saveAllUsersTime(pinano)
     pinano.channels.find(chan => chan.name === 'practice-room-chat').send({
       embed: {
         title: 'Weekly Leaderboard - Results',


### PR DESCRIPTION
#67 Deletion of locked temp room causes room to remain visible on Discord client
#44 temp-muted role overwritten in PRC when connected to a PR
#23 Commit everybody's lb times at reset

Modifies the voiceStateUpdate handler to only unlock a room if it is not a temp channel we just deleted. Also, refactor the code that handles saving an active session to client_functions.js, and call that from both the voiceStateUpdate handler as well as a new command, `p!commit`, that commits *all* active sessions to the database. The weekly leaderboard submission also calls `p!commit`, so that all sessions are saved and started fresh when the leaderboard resets.

#44 is an issue where the individual permission granted for being in a practice room overrides the deny permission given by the Temp Muted role. Therefore, don't grant that permission if the user is in Temp Muted, and just in case they're already in a practice room when they're given the role, recalculate the permission whenever a member's roles are updated.