### PR TITLE
Match permissions on extra rooms to existing rooms

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -452,7 +452,7 @@ class Commands {
       throw new Error('You do not have this channel locked.')
     }
 
-    await this.client.unlockPracticeRoom(message.guild, channel.locked_by, channel)
+    await this.client.unlockPracticeRoom(message.guild, channel)
     selfDestructMessage(() => message.reply(`unlocked channel <#${channel.id}>.`))
   }
 

--- a/library/client_events.js
+++ b/library/client_events.js
@@ -182,8 +182,10 @@ module.exports = client => {
     let tempChannelToRemove = null
     if (areAllPracticeRoomsFull(guildInfo.permitted_channels, newMember.guild)) {
       let categoryChan = newMember.guild.channels.find(chan => chan.name === 'practice-room-chat').parent
+      let pinanoBot = newMember.guild.roles.find(r => r.name === 'Pinano Bot')
       let tempMutedRole = newMember.guild.roles.find(r => r.name === 'Temp Muted')
       let verificationRequiredRole = newMember.guild.roles.find(r => r.name === 'Verification Required')
+      let everyone = newMember.guild.roles.find(r => r.name === '@everyone')
 
       let newChan = await newMember.guild.createChannel('Extra Practice Room', {
         type: 'voice',
@@ -191,11 +193,17 @@ module.exports = client => {
         bitrate: settings.dev_mode ? 96000 : 256000,
         position: categoryChan.children.size,
         permissionOverwrites: [{
+          id: pinanoBot,
+          allow: ['MANAGE_CHANNEL', 'MANAGE_ROLES']
+        }, {
           id: tempMutedRole,
           deny: ['SPEAK']
         }, {
           id: verificationRequiredRole,
           deny: ['VIEW_CHANNEL']
+        }, {
+          id: everyone,
+          deny: ['MANAGE_CHANNEL', 'MANAGE_ROLES']
         }]
       })
 

--- a/library/client_events.js
+++ b/library/client_events.js
@@ -225,7 +225,7 @@ module.exports = client => {
       oldMember.voiceChannel.locked_by === oldMember.id &&
       newMember.voiceChannelID !== oldMember.voiceChannelID) {
       // user left a room they had locked; unlock it.
-      await client.unlockPracticeRoom(oldMember.guild, oldMember.id, oldMember.voiceChannel)
+      await client.unlockPracticeRoom(oldMember.guild, oldMember.voiceChannel)
     }
 
     updatePracticeRoomChatPermissions(guildInfo.permitted_channels, newMember)

--- a/library/client_functions.js
+++ b/library/client_functions.js
@@ -33,19 +33,26 @@ module.exports = client => {
       await channel.setName(channel.unlocked_name)
     }
 
-    // remove permissions overrides
+    // reset permissions overrides
+    let pinanoBot = guild.roles.find(r => r.name === 'Pinano Bot')
+    let tempMutedRole = guild.roles.find(r => r.name === 'Temp Muted')
+    let verificationRequiredRole = guild.roles.find(r => r.name === 'Verification Required')
     let everyone = guild.roles.find(r => r.name === '@everyone')
-    await channel.overwritePermissions(everyone, { SPEAK: null })
-
-    let personalOverride = channel.permissionOverwrites.get(userId)
-    // existingOverride shouldn't be null unless someone manually deletes the override, but if for some reason it's gone, no big deal, just move on.
-    if (personalOverride != null) {
-      if (personalOverride.allowed.bitfield === Discord.Permissions.FLAGS.SPEAK && personalOverride.denied.bitfield === 0) { // the only permission was allow SPEAK
-        await personalOverride.delete()
-      } else {
-        await channel.overwritePermissions(userId, { SPEAK: null })
-      }
-    }
+    await channel.replacePermissionOverwrites({
+      overwrites: [{
+        id: pinanoBot,
+        allow: ['MANAGE_CHANNEL', 'MANAGE_ROLES']
+      }, {
+        id: tempMutedRole,
+        deny: ['SPEAK']
+      }, {
+        id: verificationRequiredRole,
+        deny: ['VIEW_CHANNEL']
+      }, {
+        id: everyone,
+        deny: ['MANAGE_CHANNEL', 'MANAGE_ROLES']
+      }]
+    })
 
     try {
       await Promise.all(channel.members.map(async m => {

--- a/library/client_functions.js
+++ b/library/client_functions.js
@@ -28,7 +28,7 @@ module.exports = client => {
     setTimeout(() => m.delete(), settings.res_destruct_time * 1000)
   }
 
-  client.unlockPracticeRoom = async (guild, userId, channel) => {
+  client.unlockPracticeRoom = async (guild, channel) => {
     if (channel.unlocked_name != null) {
       await channel.setName(channel.unlocked_name)
     }


### PR DESCRIPTION
Also replaces permissions on `p!unlock` instead of taking a delta of the permissions so that one can run `p!unlock` on a ghost-locked room and reset the permissions back to normal.