### PR TITLE
Implement anti-rickroll device

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -171,25 +171,7 @@ class Commands {
       throw new Error('This channel is already locked.')
     }
 
-    channel.locked_by = mem.id
-    if (channel.isTempRoom) {
-      channel.unlocked_name = channel.name
-      await channel.setName(`${mem.user.username}'s room`)
-    }
-    await channel.overwritePermissions(mem.user, { SPEAK: true })
-    let everyone = message.guild.roles.find(r => r.name === '@everyone')
-    await channel.overwritePermissions(everyone, { SPEAK: false }) // deny everyone speaking permissions
-    try {
-      await Promise.all(channel.members.map(async (m) => {
-        if (m !== mem && !m.deleted) {
-          return m.setMute(true)
-        }
-      }))
-    } catch (err) {
-      // this is likely an issue with trying to mute a user who has already left the channel
-      this.client.log(err)
-    }
-
+    this.client.lockPracticeRoom(message.guild, channel, mem)
     selfDestructMessage(() => message.reply(`locked channel <#${channel.id}>.`))
   }
 

--- a/library/client_events.js
+++ b/library/client_events.js
@@ -229,11 +229,6 @@ module.exports = client => {
       .map(chanId => newMember.guild.channels.get(chanId))
       .filter(chan => chan != null)
 
-    // reset autolock suppression on empty channels
-    channelList
-      .filter(chan => !chan.members.some(m => !m.deleted))
-      .forEach(chan => { chan.suppressAutolock = false })
-
     // enforce autolock on unlocked channels only
     channelList
       .filter(chan => chan.locked_by == null)


### PR DESCRIPTION
Implements automatic locking mechanisms for voice channels. The feature is designed with the principle that the bot will lock a room only if 1) the bot believes that locking is desired and 2) the bot can correctly ascertain *whom* the bot should lock the room in favour of. The following heuristics apply:

- the room is only ever eligible to autolock to one person, the intended occupant. The intended occupant is the user who was most recently the only person in the channel when the channel was last occupied by a single user. The rationale here is that if a user joins a room where there is currently another user present, it doesn't seem like they want exclusive access to the room.
- if the intended occupant ever leaves, there is no longer an intended occupant. (If leaving the room leaves only one other user in the channel, then that person becomes the intended occupant.)
- the room will only be locked if the intended occupant is unmuted for a minimum amount of time, AND no other user has unmuted within that time frame.
- if a manual unlock is ever performed, the bot will consider that as a signal that auto-locking is not desired and will suppress further application of autolock until the intended occupant leaves the channel.