### PR TITLE
Refactor guildRepository out

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 const Discord = require('discord.js')
 const cron = require('node-cron')
 const settings = require('./settings/settings.json')
-const { connect, makeUser, makeGuild } = require('./library/persistence')
+const { connect, makeUser } = require('./library/persistence')
 
 let client = new Discord.Client({ fetchAllMembers: true })
 
@@ -28,9 +28,7 @@ connect('mongodb://localhost:27017/', 'pinano').then(mongoManager => {
   client.log('Connected to database')
 
   client.userRepository = mongoManager.newUserRepository()
-  client.guildRepository = mongoManager.newGuildRepository()
   client.makeUser = makeUser
-  client.makeGuild = makeGuild
   client.login(settings.token)
     .catch((error) => {
       client.log(error)

--- a/commands.js
+++ b/commands.js
@@ -404,8 +404,6 @@ class Commands {
       badges += ':notes: This user has played in three recitals\n'
     }
 
-    badges += ':question: Mystery badge [Reveal](http://euge.ca/pinano-mystery-badge)\n'
-
     if (settings.contributors.includes(mem.id)) {
       badges += ':robot: This user contributed code to Pinano Bot on [GitHub](https://github.com/pinano-discord/Pinano-Discord-Bot)\n'
     }

--- a/commands.js
+++ b/commands.js
@@ -158,10 +158,6 @@ class Commands {
     selfDestructMessage(() => message.reply('sent you the command list.'))
   }
 
-  async leaderboard (message) {
-    throw new Error(`This command has been retired; please use [#information](http://discordapp.com/channels/188345759408717825/629841121551581204) instead.`)
-  }
-
   async lock (message) {
     let channel, mem
 
@@ -468,11 +464,6 @@ class Commands {
     await this.client.policyEnforcer.unlockPracticeRoom(message.guild, channel)
     selfDestructMessage(() => message.reply(`unlocked channel <#${channel.id}>.`))
   }
-
-  async settings (message) {
-    requireRole(message.member)
-    throw new Error(`This command has been retired; use \`${settings.prefix}rooms [ add | del(ete) | rem(ove) ] <#CHANNEL_ID>\` to register and unregister practice channels.`)
-  }
 }
 
 function loadCommands (client) {
@@ -483,12 +474,10 @@ function loadCommands (client) {
   client.commands['bitrate'] = (message) => { return c.bitrate(message) }
   client.commands['deltime'] = (message) => { return c.deltime(message) }
   client.commands['help'] = (message) => { return c.help(message) }
-  client.commands['leaderboard'] = client.commands['lb'] = (message) => { return c.leaderboard(message) }
   client.commands['lock'] = (message) => { return c.lock(message) }
   client.commands['recital'] = client.commands['recitals'] = (message) => { return c.recital(message) }
   client.commands['restart'] = client.commands['reboot'] = (message) => { return c.restart(message) }
   client.commands['rooms'] = (message) => { return c.rooms(message) }
-  client.commands['settings'] = (message) => { return c.settings(message) }
   client.commands['stats'] = (message) => { return c.stats(message) }
   client.commands['unlock'] = (message) => { return c.unlock(message) }
 }

--- a/library/client_events.js
+++ b/library/client_events.js
@@ -24,17 +24,10 @@ module.exports = client => {
       new Leaderboard(client.userRepository, 'current_session_playtime', settings.leaderboard_size)
     client.overallLeaderboard =
       new Leaderboard(client.userRepository, 'overall_session_playtime', settings.leaderboard_size)
-    client.policyEnforcer = new PolicyEnforcer(client.guildRepository, client.log)
+    client.policyEnforcer = new PolicyEnforcer(client.log)
 
     await Promise.all(settings.pinano_guilds.map(async guildId => {
       let guild = client.guilds.get(guildId)
-      let guildInfo = await client.guildRepository.load(guildId)
-      guildInfo.permitted_channels
-        .map(id => guild.channels.get(id))
-        .filter(chan => chan != null)
-        .forEach(chan => {
-          chan.isPermittedChannel = true
-        })
 
       // begin any sessions that are already in progress
       client.resume(guild)

--- a/library/persistence.js
+++ b/library/persistence.js
@@ -22,10 +22,6 @@ class MongoManager {
     return new MongoUserRepository({ userCollection: this.db.collection('users') })
   }
 
-  newGuildRepository () {
-    return new MongoGuildRepository({ guildCollection: this.db.collection('guilds') })
-  }
-
   async shutdown () {
     await this.client.close()
   }
@@ -148,41 +144,4 @@ class MongoUserRepository {
   }
 }
 
-function makeGuild (guildId) {
-  return {
-    guild: guildId,
-    welcome_toggle: false,
-    leave_toggle: false,
-    dm_welcome_toggle: false,
-    welcome_channel: '',
-    leave_channel: '',
-    welcome_message: '',
-    dm_welcome_message: '',
-    leave_message: '',
-    permitted_channels: []
-  }
-}
-
-class MongoGuildRepository {
-  constructor ({ guildCollection }) {
-    this.collection = guildCollection
-  }
-
-  async load (groupId) {
-    return this.collection.findOne({ guild: groupId })
-  }
-
-  async addToField (guildId, field, value) {
-    return this.collection.updateOne({ guild: guildId }, { $addToSet: { [field]: value } })
-  }
-
-  async removeFromField (guildId, field, value) {
-    return this.collection.updateOne({ guild: guildId }, { $pull: { [field]: value } })
-  }
-
-  async save (group) {
-    return this.collection.updateOne({ guild: group.guild }, { $set: group }, { upsert: true })
-  }
-}
-
-module.exports = { connect, makeUser, makeGuild }
+module.exports = { connect, makeUser }

--- a/library/policy_enforcer.js
+++ b/library/policy_enforcer.js
@@ -135,12 +135,14 @@ class PolicyEnforcer {
       const tempMuted = findRole(guild, 'Temp Muted')
       const verifRequired = findRole(guild, 'Verification Required')
       const everyone = findRole(guild, '@everyone')
+      const identifiers = ['☀️', '🌙', '️🐢', '🐌', '🌎', '🌍', '🌏', '🔥', '💧', '🍃', '🗿', '👻', '🐉', '👁️', '👊', '🐦', '🐛', '❄️']
 
-      await guild.createChannel('Practice Room', {
+      let identifier = identifiers[Math.floor(Math.random() * identifiers.length)]
+      await guild.createChannel(`Practice Room ${identifier}`, {
         type: 'voice',
         parent: categoryChan,
         bitrate: settings.dev_mode ? 96000 : 384000,
-        position: basePosition + rooms.size,
+        position: basePosition + rooms.size + 1,
         permissionOverwrites: [{
           id: pinanoBot,
           allow: ['MANAGE_CHANNELS', 'MANAGE_ROLES']

--- a/library/policy_enforcer.js
+++ b/library/policy_enforcer.js
@@ -135,7 +135,26 @@ class PolicyEnforcer {
       const tempMuted = findRole(guild, 'Temp Muted')
       const verifRequired = findRole(guild, 'Verification Required')
       const everyone = findRole(guild, '@everyone')
-      const identifiers = ['☀️', '🌙', '️🐢', '🐌', '🌎', '🌍', '🌏', '🔥', '💧', '🍃', '🗿', '👻', '🐉', '👁️', '👊', '🐦', '🐛', '❄️']
+      const identifiers = [
+        '☀️',
+        '🌙',
+        '️🐢',
+        '🐌',
+        '🌎',
+        '🌍',
+        '🌏',
+        '🔥',
+        '💧',
+        '🍃',
+        '🗿',
+        '👻',
+        '🐉',
+        '👁️',
+        '👊',
+        '🐦',
+        '🐛',
+        '❄️'
+      ]
 
       let identifier = identifiers[Math.floor(Math.random() * identifiers.length)]
       await guild.createChannel(`Practice Room ${identifier}`, {

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -15,5 +15,6 @@
 
     "leaderboard_size" : 10,
     "res_destruct_time" : 30,
-    "req_destruct_time" : 3
+    "req_destruct_time" : 3,
+    "minimum_rooms" : 4
 }

--- a/tests/persistence.int.test.js
+++ b/tests/persistence.int.test.js
@@ -2,12 +2,10 @@ const { connect, makeUser } = require('../library/persistence')
 
 let mongoManager
 let userRepository
-let guildRepository
 
 beforeAll(async () => {
   mongoManager = await connect('mongodb://localhost:27017', 'test_db', { socketTimeoutMS: 500 })
   userRepository = mongoManager.newUserRepository()
-  guildRepository = mongoManager.newGuildRepository()
 })
 beforeEach(async () => {
   await mongoManager.dropDatabase()
@@ -18,7 +16,6 @@ afterAll(async () => {
 
 test('connects to mongo', async () => {
   expect(userRepository).not.toBeNull()
-  expect(guildRepository).not.toBeNull()
 })
 
 test('can store user', async () => {


### PR DESCRIPTION
Deprecates `p!rooms` competely, removes `p!settings` and `p!leaderboard`, and automatically considers any voice channels under the same parent as #practice-room-chat as practice channels. The last part means that there is no need for guildRepository anymore.