### PR TITLE
Remove dev_mode and beta_ settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,20 @@ And run any tests:
 
     npm test
 
+# Testing instructions
+
 If you'd like to actually run a test bot, you will need to follow the instructions to
-[create a bot user](https://discordjs.guide/preparations/setting-up-a-bot-application.html)
-and then update your `settings/settings.json` file with the appropriate `beta_token` etc.
+[create a bot user](https://discordjs.guide/preparations/setting-up-a-bot-application.html).
+
+Set the following environment variables customize what the bot connects to and what messages
+it responds to:
+
+    export PINANO_TOKEN='your token here'
+    export PINANO_PREFIX='x!!'
+    export PINANO_DEFAULT_BITRATE=96
+
+The token can be obtained from the bot's Discord settings page.
+
 
 # Contribution instructions
 

--- a/app.js
+++ b/app.js
@@ -5,10 +5,14 @@ const { connect, makeUser } = require('./library/persistence')
 
 let client = new Discord.Client({ fetchAllMembers: true })
 
-// check devmode state
-if (settings.dev_mode) {
-  settings.token = settings.beta_token
-  settings.prefix = settings.beta_prefix
+if (process.env.PINANO_TOKEN !== undefined) {
+  settings.token = process.env.PINANO_TOKEN
+}
+if (process.env.PINANO_PREFIX !== undefined) {
+  settings.prefix = process.env.PINANO_PREFIX
+}
+if (process.env.PINANO_DEFAULT_BITRATE !== undefined) {
+  settings.default_bitrate = process.env.PINANO_DEFAULT_BITRATE
 }
 
 require('./library/client_functions.js')(client)

--- a/library/policy_enforcer.js
+++ b/library/policy_enforcer.js
@@ -298,7 +298,7 @@ class PolicyEnforcer {
   }
 
   async resetBitrateIfEmpty (channel) {
-    let defaultBitrate = settings.dev_mode ? 96 : 384
+    let defaultBitrate = settings.default_bitrate
     if (channel != null &&
       !channel.members.some(m => !m.deleted) &&
       channel.bitrate !== defaultBitrate) {

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1,9 +1,7 @@
 {
-    "dev_mode" : true,
     "prefix" : "p!",
-    "beta_prefix" : "p!!",
     "token" : "",
-    "beta_token" : "",
+    "default_bitrate": 384,
     "embed_color" : 16752128,
     "activity" : "type: p!help",
     "bot_devs": [ "174511937151827969", "187548138456743936" ],


### PR DESCRIPTION
Eliminate the concept of dev_mode so that there can be no opportunity
for us to introduce code that is contingent on the concept of dev vs
production. Instead, move configuration for key parameters into
environment variables.

This means that developers can set a local variable to their test bot
tokens, etc without having to modify the settings.json file in the repo.