### PR TITLE
add jest-date-mock to fix tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3310,6 +3310,12 @@
         "realpath-native": "^2.0.0"
       }
     },
+    "jest-date-mock": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/jest-date-mock/-/jest-date-mock-1.0.8.tgz",
+      "integrity": "sha512-0Lyp+z9xvuNmLbK+5N6FOhSiBeux05Lp5bbveFBmYo40Aggl2wwxFoIrZ+rOWC8nDNcLeBoDd2miQdEDSf3iQw==",
+      "dev": true
+    },
     "jest-diff": {
       "version": "25.3.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "jest": "^25.3.0",
+    "jest-date-mock": "^1.0.8",
     "standard": "^12.0.1"
   },
   "scripts": {


### PR DESCRIPTION
I don't know how the build works in CI without this, must not nuke the old env before building again.