### PR TITLE
subscriptions: use username#discriminator instead of mention

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -19,9 +19,9 @@ async function help (client, message) {
     'Locks the currently occupied room for exclusive use')
   msg.addField(`\`${settings.prefix}bitrate [ BITRATE_IN_KBPS ]\``,
     'Adjusts the bitrate of the currently occupied room')
-  msg.addField(`\`${settings.prefix}subscribe @user\``,
+  msg.addField(`\`${settings.prefix}subscribe username#discriminator\``,
     'Get a DM when @user starts practicing')
-  msg.addField(`\`${settings.prefix}unsubscribe @user\``,
+  msg.addField(`\`${settings.prefix}unsubscribe username#discriminator\``,
     'Stop getting a DM when @user starts practicing')
 
   if (isBotManager) {

--- a/commands/helpers.js
+++ b/commands/helpers.js
@@ -20,6 +20,16 @@ function requireParameterFormat (arg, formatFn, usageStr) {
   }
 }
 
+function memberFromQualifiedName (args, members) {
+  // fqName: "fully qualified name"
+  const fqName = args.join(' ').trim().split('#')
+  if (fqName.length !== 2) {
+    throw new Error('unable to parse name of form username#discriminator')
+  }
+  return members.find(val => val.user.username === fqName[0] &&
+    val.user.discriminator === fqName[1])
+}
+
 async function selfDestructMessage (messageFn) {
   let m = await messageFn()
   setTimeout(() => m.delete(), settings.res_destruct_time * 1000)
@@ -39,6 +49,7 @@ module.exports = {
   requireRole,
   requireParameterCount,
   requireParameterFormat,
+  memberFromQualifiedName,
   selfDestructMessage,
   abbreviateTime
 }

--- a/commands/subscriptions.js
+++ b/commands/subscriptions.js
@@ -1,9 +1,11 @@
 const {
+  memberFromQualifiedName,
   selfDestructMessage
 } = require('./helpers')
 
 async function subscribe (client, message) {
-  const subscribee = message.mentions.users.first()
+  const args = message.content.split(' ').splice(1)
+  const subscribee = memberFromQualifiedName(args, message.guild.members)
   if (subscribee == null) {
     throw new Error('Must subscribe to a user!')
   }
@@ -12,7 +14,8 @@ async function subscribe (client, message) {
 }
 
 async function unsubscribe (client, message) {
-  const subscribee = message.mentions.users.first()
+  const args = message.content.split(' ').splice(1)
+  const subscribee = memberFromQualifiedName(args, message.guild.members)
   if (subscribee == null) {
     throw new Error('Must unsubscribe to a user!')
   }


### PR DESCRIPTION
Because we delete messages, using a mention results in a ghost ping
which is annoying. Instead, parse a member using a username#discriminator.

(Completely untested.)