### PR TITLE
subscriptions: Use lock not session as notification trigger

### DIFF
--- a/library/client_events.js
+++ b/library/client_events.js
@@ -49,7 +49,9 @@ module.exports = client => {
       new SessionManager(client.userRepository, client.log)
     client.policyEnforcer = new PolicyEnforcer(client.log)
     client.quizMaster = new QuizMaster(client.userRepository)
-    client.subscriberManager = new SubscriberManager(client, client.sessionManager, client.userRepository)
+    client.subscriberManager = new SubscriberManager(client, client.userRepository)
+
+    client.policyEnforcer.on('lockPracticeRoom', (member) => client.subscriberManager.notify(member))
 
     await Promise.all(settings.pinano_guilds.map(async guildId => {
       let guild = client.guilds.get(guildId)

--- a/library/policy_enforcer.js
+++ b/library/policy_enforcer.js
@@ -2,6 +2,7 @@
 const settings = require('../settings/settings.json')
 const Discord = require('discord.js')
 const moment = require('moment')
+const EventEmitter = require('events')
 
 function findChannel (guild, name) {
   return guild.channels.find(c => c.name === name)
@@ -30,8 +31,9 @@ const RoomIdentifiers = {
 }
 Object.freeze(RoomIdentifiers)
 
-class PolicyEnforcer {
+class PolicyEnforcer extends EventEmitter {
   constructor (logFn) {
+    super()
     this.logFn_ = logFn
   }
 
@@ -62,6 +64,8 @@ class PolicyEnforcer {
       // this is likely an issue with trying to mute a user who has already left the channel
       this.logFn_(err)
     }
+
+    this.emit('lockPracticeRoom', member)
   }
 
   async unlockPracticeRoom (guild, channel) {

--- a/library/session_manager.js
+++ b/library/session_manager.js
@@ -1,11 +1,9 @@
 const moment = require('moment')
-const EventEmitter = require('events')
 
 const settings = require('../settings/settings.json')
 
-class SessionManager extends EventEmitter {
+class SessionManager {
   constructor (userRepository, logFn) {
-    super()
     this.userRepository_ = userRepository
     this.logFn_ = logFn
   }
@@ -16,12 +14,6 @@ class SessionManager extends EventEmitter {
     if (member.s_time == null) {
       this.logFn_(`Beginning session for user <@${member.id}> ${username}#${discriminator}`)
       member.s_time = moment().unix()
-
-      setTimeout(() => {
-        if (member.s_time != null) {
-          this.emit('startPractice', member)
-        }
-      }, settings.practice_session_minimum_time * 1000)
     }
   }
 

--- a/library/subscriber_manager.js
+++ b/library/subscriber_manager.js
@@ -1,15 +1,12 @@
 const settings = require('../settings/settings.json')
 
 class SubscriberManager {
-  constructor (client, sessionManager, userRepository) {
+  constructor (client, userRepository) {
     this.client_ = client
-    this.sessionManager_ = sessionManager
     this.userRepository_ = userRepository
-
-    this.sessionManager_.on('startPractice', (member) => this.handleStartPractice(member))
   }
 
-  async handleStartPractice (member) {
+  async notify (member) {
     const user = await this.userRepository_.load(member.id)
     for (const subId of user.subscribers) {
       const sub = this.client_.users.get(subId)


### PR DESCRIPTION
This may help resolve #184. The hypothesis is that if someone mutes and
unmutes inside a channel, they retain the lock on a channel but we start
a new session. By using lock instead of session, this should prevent
mute toggling from causing further notifications. Also, auto-lock
happens faster than session start so you'll get a prompt-er
notification.