### PR TITLE
Don't crash when someone else adds a room

### DIFF
--- a/modules/policy_enforcer.js
+++ b/modules/policy_enforcer.js
@@ -209,6 +209,7 @@ class PolicyEnforcer extends EventEmitter {
       this._applyRoomAutocreationPolicy()
     }
     const tracker = this._pracman._tracker[channelId]
+    if (tracker == null) return
     if (tracker.lockedBy == null) {
       this._enforceAutolock(channelId)
     } else {
@@ -222,8 +223,10 @@ class PolicyEnforcer extends EventEmitter {
     if (this._config.get('enableRoomAutocreation')) {
       removedChannelId = await this._applyRoomAutodeletionPolicy()
     }
+    const tracker = this._pracman._tracker[channelId]
+    if (tracker == null) return
     if (removedChannelId !== channelId) {
-      if (this._pracman._tracker[channelId].lockedBy === userId) {
+      if (tracker.lockedBy === userId) {
         this._unlockPracticeRoom(this._guild.channels.cache.get(channelId))
       }
       this._enforceAutolock(channelId)
@@ -269,6 +272,7 @@ class PolicyEnforcer extends EventEmitter {
 
     const channel = this._guild.channels.resolve(channelId)
     const tracker = this._pracman._tracker[channelId]
+    if (tracker == null) return
     if (channel.members.get(tracker.occupant) == null) {
       // occupant has left this room, clear out the value. Basically, start over again.
       // We will destroy the task if it exists below.

--- a/modules/practice_adapter.js
+++ b/modules/practice_adapter.js
@@ -52,7 +52,8 @@ class PracticeAdapter extends EventEmitter {
         return
       }
 
-      this.emit('createPracticeRoom', channel.id, channel.name.includes('Feedback'), channel.name.match(/Room (.*?)$/)[1])
+      const tokenMatch = channel.name.match(/Room (.*?)$/)
+      this.emit('createPracticeRoom', channel.id, channel.name.includes('Feedback'), (tokenMatch == null) ? null : tokenMatch[1])
     })
     dispatcher.on('channelDelete', this._guild.id, channel => {
       if (channel.parent !== this._category) {
@@ -341,15 +342,11 @@ class PracticeAdapter extends EventEmitter {
   }
 
   adjustChannelName (channelId, isLocked, isFeedback, token) {
+    // don't adjust channel names when we don't have a token; it's probably a custom room.
+    if (token == null) return
     const channel = this._guild.channels.cache.get(channelId)
     if (channel != null) {
       return channel.setName(`${isLocked ? '🔒' : ''} ${isFeedback ? 'Feedback' : 'Practice'} Room ${token}`)
-    }
-  }
-
-  notifyUntrackedRoom (channelId) {
-    if (this._announcementsChannel != null) {
-      this._announcementsChannel.send(`WARNING: not tracking time for <#${channelId}>.`)
     }
   }
 }

--- a/modules/practice_adapter.js
+++ b/modules/practice_adapter.js
@@ -346,6 +346,12 @@ class PracticeAdapter extends EventEmitter {
       return channel.setName(`${isLocked ? '🔒' : ''} ${isFeedback ? 'Feedback' : 'Practice'} Room ${token}`)
     }
   }
+
+  notifyUntrackedRoom (channelId) {
+    if (this._announcementsChannel != null) {
+      this._announcementsChannel.send(`WARNING: not tracking time for <#${channelId}>.`)
+    }
+  }
 }
 
 function makeModule (moduleManager) {

--- a/modules/practice_manager.js
+++ b/modules/practice_manager.js
@@ -46,34 +46,50 @@ class PracticeManager extends EventEmitter {
 
     this._adapter.on('joinPracticeRoom', (userId, channelId, isMuted, isDeaf) => {
       log(`joinPracticeRoom ${userId} ${channelId} ${isMuted} ${isDeaf}`)
-      if (!isMuted) {
-        this._startPracticing(userId, channelId)
-      } else if (!isDeaf) {
-        this._startListening(userId, channelId)
+      if (this._tracker[channelId] != null) {
+        if (!isMuted) {
+          this._startPracticing(userId, channelId)
+        } else if (!isDeaf) {
+          this._startListening(userId, channelId)
+        }
+      } else {
+        logError(`Ignoring joinPracticeRoom event for channel ${channelId} because there is no channel tracker.`)
       }
     })
 
     this._adapter.on('leavePracticeRoom', (userId, channelId, wasMuted, wasDeaf) => {
       log(`leavePracticeRoom ${userId} ${channelId} ${wasMuted} ${wasDeaf}`)
-      if (!wasMuted) {
-        this._stopPracticing(userId, channelId)
-      } else if (!wasDeaf) {
-        this._stopListening(userId, channelId)
+      if (this._tracker[channelId] != null) {
+        if (!wasMuted) {
+          this._stopPracticing(userId, channelId)
+        } else if (!wasDeaf) {
+          this._stopListening(userId, channelId)
+        }
+      } else {
+        logError(`Ignoring leavePracticeRoom event for channel ${channelId} because there is no channel tracker.`)
       }
     })
 
     this._adapter.on('switchPracticeRoom', (userId, oldChannelId, newChannelId, wasMuted, wasDeaf, isMuted, isDeaf) => {
       log(`switchPracticeRoom ${userId} ${oldChannelId} ${newChannelId} ${wasMuted} ${wasDeaf} ${isMuted} ${isDeaf}`)
-      if (!wasMuted) {
-        this._stopPracticing(userId, oldChannelId)
-      } else if (!wasDeaf) {
-        this._stopListening(userId, oldChannelId)
+      if (this._tracker[oldChannelId] != null) {
+        if (!wasMuted) {
+          this._stopPracticing(userId, oldChannelId)
+        } else if (!wasDeaf) {
+          this._stopListening(userId, oldChannelId)
+        }
+      } else {
+        logError(`Ignoring switchPracticeRoom event for channel ${oldChannelId} because there is no channel tracker.`)
       }
 
-      if (!isMuted) {
-        this._startPracticing(userId, newChannelId)
-      } else if (!isDeaf) {
-        this._startListening(userId, newChannelId)
+      if (this._tracker[newChannelId] != null) {
+        if (!isMuted) {
+          this._startPracticing(userId, newChannelId)
+        } else if (!isDeaf) {
+          this._startListening(userId, newChannelId)
+        }
+      } else {
+        logError(`Ignoring switchPracticeRoom event for channel ${newChannelId} because there is no channel tracker.`)
       }
     })
 
@@ -220,10 +236,6 @@ class PracticeManager extends EventEmitter {
 
   _startPracticing (userId, channelId) {
     log(`- startPracticing ${userId} ${channelId}`)
-    if (this._tracker[channelId] == null) {
-      logError(`startPracticing failed because there is no channel tracker for channel ${channelId}.`)
-      return
-    }
     this._tracker[channelId].live.push({
       id: userId,
       since: this._timestampFn()
@@ -232,10 +244,6 @@ class PracticeManager extends EventEmitter {
 
   _startListening (userId, channelId) {
     log(`- startListening ${userId} ${channelId}`)
-    if (this._tracker[channelId] == null) {
-      logError(`startListening failed because there is no channel tracker for channel ${channelId}.`)
-      return
-    }
     this._tracker[channelId].listening.push({
       id: userId,
       since: this._timestampFn()
@@ -245,10 +253,6 @@ class PracticeManager extends EventEmitter {
   _stopPracticing (userId, channelId) {
     log(`- stopPracticing ${userId} ${channelId}`)
     const channelTracker = this._tracker[channelId]
-    if (channelTracker == null) {
-      logError(`stopPracticing failed because there is no channel tracker for channel ${channelId}.`)
-      return
-    }
     const currentTimestamp = this._timestampFn()
     const index = channelTracker.live.findIndex(r => r.id === userId)
     if (index === -1) {
@@ -285,10 +289,6 @@ class PracticeManager extends EventEmitter {
   _stopListening (userId, channelId) {
     log(`- stopListening ${userId} ${channelId}`)
     const channelTracker = this._tracker[channelId]
-    if (channelTracker == null) {
-      logError(`stopListening failed because there is no channel tracker for channel ${channelId}.`)
-      return
-    }
     const currentTimestamp = this._timestampFn()
     const index = channelTracker.listening.findIndex(r => r.id === userId)
     if (index === -1) {

--- a/modules/practice_manager.js
+++ b/modules/practice_manager.js
@@ -220,6 +220,10 @@ class PracticeManager extends EventEmitter {
 
   _startPracticing (userId, channelId) {
     log(`- startPracticing ${userId} ${channelId}`)
+    if (this._tracker[channelId] == null) {
+      logError(`startPracticing failed because there is no channel tracker for channel ${channelId}.`)
+      return
+    }
     this._tracker[channelId].live.push({
       id: userId,
       since: this._timestampFn()
@@ -228,6 +232,10 @@ class PracticeManager extends EventEmitter {
 
   _startListening (userId, channelId) {
     log(`- startListening ${userId} ${channelId}`)
+    if (this._tracker[channelId] == null) {
+      logError(`startListening failed because there is no channel tracker for channel ${channelId}.`)
+      return
+    }
     this._tracker[channelId].listening.push({
       id: userId,
       since: this._timestampFn()


### PR DESCRIPTION
Three recent crashes saw the following sequence: an admin added a room; the room wasn't tracked since the bot didn't create it; when someone joined the room, we tried to get a channel tracker and failed, and then crashed dereferencing the pointer. This change makes it so that when the autocreation feature is enabled, rooms added by users other than the bot are not tracked by the bot (nor are they auto-locked), and warns the announcement channel upon creation if that is the case.

(This does not apply if the room autocreation feature is turned off - in that case the bot is explicitly depending upon an outside process to create and delete rooms for it.)