### PR TITLE
Bugfix: pinonavirus causes p!stats to fail when user doesn't have a token list

### DIFF
--- a/modules/badges.js
+++ b/modules/badges.js
@@ -100,7 +100,7 @@ class Badges {
       badges.push(`${this._config.get('streakBadgeIcon')} I practiced for ${Math.max(currentStreak, userRecord.max_daily_streak)} days in a row`)
     }
 
-    if (this._config.get('virusBadge') != null && now >= userRecord.virus_visible_at && !userRecord.rooms_practiced.includes('💉')) {
+    if (this._config.get('virusBadge') != null && now >= userRecord.virus_visible_at && (userRecord.rooms_practice == null || !userRecord.rooms_practiced.includes('💉'))) {
       badges.push(this._config.get('virusBadge'))
     }
 


### PR DESCRIPTION
Missing a null check.