### PR TITLE
Disallow users from skipping their own riddles unless they have the appropriate role

### DIFF
--- a/modules/quiz_adapter.js
+++ b/modules/quiz_adapter.js
@@ -198,7 +198,7 @@ class QuizAdapter {
 
   nagQuizzer (quizzerId) {
     this._channel.send(`<@${quizzerId}>: your riddle has been active for a while.\n\n` +
-      'Please mark guesses as correct or incorrect, or consider skipping the riddle if no progress is made.')
+      'The riddle may be skipped if no progress is made.')
   }
 
   giveHint (hint) {
@@ -421,7 +421,7 @@ class QuizAdapter {
   }
 
   _skipReaction (riddle, reaction, reactor) {
-    if (reaction.emoji.name === '⏩' && this._controlsQuestion(riddle, reactor)) {
+    if (reaction.emoji.name === '⏩' && this._isQuizMaster(reactor)) {
       this._quizModule.endRiddle(riddle.quizzerId)
     } else {
       reaction.users.remove(reactor)


### PR DESCRIPTION
Hopefully this will disincentivize people who regularly submit terrible riddles and skip them when they get zero engagement.